### PR TITLE
Correct preformat text gone awry

### DIFF
--- a/pages/neuroimaging/neuroimaging-afnibootcamp.md
+++ b/pages/neuroimaging/neuroimaging-afnibootcamp.md
@@ -76,13 +76,13 @@ nifti_tool -disp_hdr -input T1.nii.gz
 ## Keeping up AFNI
 Update AFNI using:
 
-```{bash, eval=FALSE}
+```
 @update.afni.binaries
 ```
 
 To get the afni version number, type
 
-```{bash, eval=FALSE}
+```
 afni -ver
 ```
     

--- a/pages/neuroimaging/neuroimaging-afnibootcamp.md
+++ b/pages/neuroimaging/neuroimaging-afnibootcamp.md
@@ -75,11 +75,13 @@ nifti_tool -disp_hdr -input T1.nii.gz
 
 ## Keeping up AFNI
 Update AFNI using:
+
 ```{bash, eval=FALSE}
 @update.afni.binaries
 ```
 
 To get the afni version number, type
+
 ```{bash, eval=FALSE}
 afni -ver
 ```


### PR DESCRIPTION
Hi, Tara,

I was looking at the AFNI bootcamp page, and there were two blocks of preformatted text that needed a gentle nudge.  This should fix them.  The triple backticks weren't liking the the {BASH...} modifier, and they want a blank line before them.

I hope all is well there.  -- bennet